### PR TITLE
fix `ICav31_Ma2020` bug

### DIFF
--- a/dendritex/channels/calcium.py
+++ b/dendritex/channels/calcium.py
@@ -1051,17 +1051,14 @@ class ICav31_Ma2020(CalciumChannel):
     def f_q_tau(self, V):
         return self.C_tau_h + self.A_tau_h / u.math.exp((V - self.v0_tau_h1) / self.k_tau_h1)
 
-    def ghk(self, V, Ca: IonInfo):
-        E = (1e-3) * V
-        zeta = (self.z * u.faraday_constant * E) / (u.gas_constant * (273.15 + self.T) * u.kelvin)
-        ci = Ca.C
-        co = 2 * u.mM  # co = Ca.C0 for Calciumdetailed
-        g_1 = 1e-6 * (self.z * u.faraday_constant) * (ci - co * u.math.exp(-zeta)) * (1 + zeta / 2)
-        g_2 = 1e-6 * (self.z * zeta * u.faraday_constant) * (ci - co * u.math.exp(-zeta)) / (1 - u.math.exp(-zeta))
+    def ghk(self, V, ci, co = 2 * u.mM):
+        zeta = (self.z * u.faraday_constant * V) / (u.gas_constant * u.celsius2kelvin(self.T))
+        g_1 = (self.z * u.faraday_constant) * (ci - co * u.math.exp(-zeta)) * (1 + zeta / 2)
+        g_2 = (self.z * zeta * u.faraday_constant) * (ci - co * u.math.exp(-zeta)) / (1 - u.math.exp(-zeta))
         return u.math.where(u.math.abs((1 - u.math.exp(-zeta))) <= 1e-6, g_1, g_2)
 
     def current(self, V, Ca: IonInfo):
-        return -1e3 * self.g_max * self.p.value ** 2 * self.q.value * self.ghk(V, Ca)
+        return -self.g_max * self.p.value ** 2 * self.q.value * self.ghk(V, Ca.C)
 
 
 class ICaGrc_Ma2020(CalciumChannel):


### PR DESCRIPTION
This pull request includes changes to the `dendritex/channels/calcium.py` file to simplify and improve the `ghk` function and its usage. The most important changes include modifying the `ghk` function to accept direct ion concentrations as parameters and updating the `current` function to use the new `ghk` function signature.

Simplification and improvements:

* [`dendritex/channels/calcium.py`](diffhunk://#diff-b254f15c01db1c1f2c091750c7ddb57745c61888884b80f4220f5b17ab9b228aL1054-R1061): Modified the `ghk` function to accept `ci` and `co` as parameters directly, removing the dependency on the `IonInfo` class for calcium concentration.
* [`dendritex/channels/calcium.py`](diffhunk://#diff-b254f15c01db1c1f2c091750c7ddb57745c61888884b80f4220f5b17ab9b228aL1054-R1061): Updated the `current` function to call the modified `ghk` function with `Ca.C` instead of the entire `IonInfo` object.