### PR TITLE
Standardize integration methods

### DIFF
--- a/dendritex/_integrators.py
+++ b/dendritex/_integrators.py
@@ -22,9 +22,52 @@ import brainstate as bst
 import brainunit as u
 import diffrax as dfx
 import jax
+from brainstate._state import record_state_value_write
 
-from ._base import State4Integral, DendriteDynamics
 from ._misc import set_module_as
+
+
+class State4Integral(bst.ShortTermState):
+    """
+    A state that integrates the state of the system to the integral of the state.
+
+    Attributes
+    ----------
+    derivative: The derivative of the state.
+
+    """
+
+    __module__ = 'dendritex'
+
+    # derivative of this state
+    derivative: bst.typing.PyTree
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._derivative = None
+
+    @property
+    def derivative(self):
+        return self._derivative
+
+    @derivative.setter
+    def derivative(self, value):
+        record_state_value_write(self)
+        self._derivative = value
+
+
+class DiffEqModule(bst.mixin.Mixin):
+    __module__ = 'dendritex'
+
+    def pre_integral(self, *args, **kwargs):
+        pass
+
+    def compute_derivative(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def post_integral(self, *args, **kwargs):
+        pass
+
 
 __all__ = [
     'diffrax_solve_adjoint',
@@ -360,7 +403,12 @@ class ButcherTableau:
     C: Sequence  # The C vector in the Butcher tableau.
 
 
-def _update(dt, coeff, st, y0, *ks):
+def _rk_update(
+    coeff: Sequence,
+    st: bst.State,
+    y0: bst.typing.PyTree,
+    *ks
+):
     assert len(coeff) == len(ks), 'The number of coefficients must be equal to the number of ks.'
 
     def _step(y0_, *k_):
@@ -368,7 +416,7 @@ def _update(dt, coeff, st, y0, *ks):
         update = kds[0]
         for kd in kds[1:]:
             update += kd
-        return y0_ + update * dt
+        return y0_ + update * bst.environ.get_dt()
 
     st.value = jax.tree.map(_step, y0, *ks, is_leaf=u.math.is_quantity)
 
@@ -376,44 +424,46 @@ def _update(dt, coeff, st, y0, *ks):
 @set_module_as('dendritex')
 def _general_rk_step(
     tableau: ButcherTableau,
-    target: DendriteDynamics,
+    target: DiffEqModule,
     t: jax.typing.ArrayLike,
     *args
 ):
     dt = bst.environ.get_dt()
-    time_dtype = u.math.get_dtype(dt)
+
+    # Runge-Kutta stages
     ks = []
 
     # before one-step integration
-    target.before_integral(*args)
+    target.pre_integral(*args)
 
-    # k1
-    with bst.environ.context(t=t + u.math.asarray(tableau.C[0], dtype=time_dtype) * dt):
+    # k1: first derivative step
+    assert len(tableau.A[0]) == 0, f'The first row of A must be empty. Got {tableau.A[0]}'
+    with bst.environ.context(t=t + tableau.C[0] * dt):
         with bst.StateTraceStack() as trace:
             # compute derivative
             target.compute_derivative(*args)
 
-            # state collection
-            states = tuple([st for st in trace.states if isinstance(st, State4Integral)])
-
-            # initial values
-            y0 = list([
-                val
-                for st, val in zip(trace.states, trace.original_state_values)
-                if isinstance(st, State4Integral)
-            ])
-
-            # derivatives
-            k1hs = [st.derivative for st in states]
+            # collection of states, initial values, and derivatives
+            states = []  # states
+            k1hs = []  # k1hs: k1 holder
+            y0 = []  # initial values
+            for st, val, writen in zip(trace.states, trace.original_state_values, trace.been_writen):
+                if isinstance(st, State4Integral):
+                    assert writen, f'State {st} must be written.'
+                    y0.append(val)
+                    states.append(st)
+                    k1hs.append(st.derivative)
+                else:
+                    if writen:
+                        raise ValueError(f'State {st} is not for integral.')
             ks.append(k1hs)
 
+    # intermediate steps
     for i in range(1, len(tableau.C)):
-        with bst.environ.context(t=t + u.math.asarray(tableau.C[i], dtype=time_dtype) * dt):
+        with bst.environ.context(t=t + tableau.C[i] * dt):
             with bst.check_state_value_tree():
                 for st, y0_, *ks_ in zip(states, y0, *ks):
-                    _update(dt, tableau.A[i], st, y0_, *ks_)
-                # after one-step derivative
-                target.post_derivative(*args)
+                    _rk_update(tableau.A[i], st, y0_, *ks_)
             target.compute_derivative(*args)
             ks.append([st.derivative for st in states])
 
@@ -421,9 +471,7 @@ def _general_rk_step(
     with bst.check_state_value_tree():
         # update states with derivatives
         for st, y0_, *ks_ in zip(states, y0, *ks):
-            _update(dt, tableau.B, st, y0_, *ks_)
-        # update other states
-        target.post_derivative(*args)
+            _rk_update(tableau.B, st, y0_, *ks_)
 
 
 euler_tableau = ButcherTableau(
@@ -432,107 +480,125 @@ euler_tableau = ButcherTableau(
     C=(0.0,),
 )
 midpoint_tableau = ButcherTableau(
-    A=[(), (0.5,)],
+    A=[(),
+       (0.5,)],
     B=(0.0, 1.0),
     C=(0.0, 0.5),
 )
 rk2_tableau = ButcherTableau(
-    A=[(), (2 / 3,)],
+    A=[(),
+       (2 / 3,)],
     B=(1 / 4, 3 / 4),
     C=(0.0, 2 / 3),
 )
 heun2_tableau = ButcherTableau(
-    A=[(), (1.,)],
+    A=[(),
+       (1.,)],
     B=[0.5, 0.5],
     C=[0, 1],
 )
 ralston2_tableau = ButcherTableau(
-    A=[(), (2 / 3,)],
+    A=[(),
+       (2 / 3,)],
     B=[0.25, 0.75],
     C=[0, 2 / 3],
 )
 rk3_tableau = ButcherTableau(
-    A=[(), (0.5,), (-1, 2)],
+    A=[(),
+       (0.5,),
+       (-1, 2)],
     B=[1 / 6, 2 / 3, 1 / 6],
     C=[0, 0.5, 1],
 )
 heun3_tableau = ButcherTableau(
-    A=[(), (1 / 3,), (0, 2 / 3)],
+    A=[(),
+       (1 / 3,),
+       (0, 2 / 3)],
     B=[0.25, 0, 0.75],
     C=[0, 1 / 3, 2 / 3],
 )
 ralston3_tableau = ButcherTableau(
-    A=[(), (0.5,), (0, 0.75)],
+    A=[(),
+       (0.5,),
+       (0, 0.75)],
     B=[2 / 9, 1 / 3, 4 / 9],
     C=[0, 0.5, 0.75],
 )
 ssprk3_tableau = ButcherTableau(
-    A=[(), (1,), (0.25, 0.25)],
+    A=[(),
+       (1,),
+       (0.25, 0.25)],
     B=[1 / 6, 1 / 6, 2 / 3],
     C=[0, 1, 0.5],
 )
 rk4_tableau = ButcherTableau(
-    A=[(), (0.5,), (0., 0.5), (0., 0., 1)],
+    A=[(),
+       (0.5,),
+       (0., 0.5),
+       (0., 0., 1)],
     B=[1 / 6, 1 / 3, 1 / 3, 1 / 6],
     C=[0, 0.5, 0.5, 1],
 )
 ralston4_tableau = ButcherTableau(
-    A=[(), (.4,), (.29697761, .15875964), (.21810040, -3.05096516, 3.83286476)],
+    A=[(),
+       (.4,),
+       (.29697761, .15875964),
+       (.21810040, -3.05096516, 3.83286476)],
     B=[.17476028, -.55148066, 1.20553560, .17118478],
     C=[0, .4, .45573725, 1],
 )
 
 
 @set_module_as('dendritex')
-def euler_step(target: DendriteDynamics, t: bst.typing.ArrayLike, *args):
+def euler_step(target: DiffEqModule, t: bst.typing.ArrayLike, *args):
     _general_rk_step(euler_tableau, target, t, *args)
 
 
 @set_module_as('dendritex')
-def midpoint_step(target: DendriteDynamics, t: bst.typing.ArrayLike, *args):
+def midpoint_step(target: DiffEqModule, t: bst.typing.ArrayLike, *args):
     _general_rk_step(midpoint_tableau, target, t, *args)
 
 
 @set_module_as('dendritex')
-def rk2_step(target: DendriteDynamics, t: bst.typing.ArrayLike, *args):
+def rk2_step(target: DiffEqModule, t: bst.typing.ArrayLike, *args):
     _general_rk_step(rk2_tableau, target, t, *args)
 
 
 @set_module_as('dendritex')
-def heun2_step(target: DendriteDynamics, t: bst.typing.ArrayLike, *args):
+def heun2_step(target: DiffEqModule, t: bst.typing.ArrayLike, *args):
     _general_rk_step(heun2_tableau, target, t, *args)
 
 
 @set_module_as('dendritex')
-def ralston2_step(target: DendriteDynamics, t: bst.typing.ArrayLike, *args):
+def ralston2_step(target: DiffEqModule, t: bst.typing.ArrayLike, *args):
     _general_rk_step(ralston2_tableau, target, t, *args)
 
 
 @set_module_as('dendritex')
-def rk3_step(target: DendriteDynamics, t: bst.typing.ArrayLike, *args):
+def rk3_step(target: DiffEqModule, t: bst.typing.ArrayLike, *args):
     _general_rk_step(rk3_tableau, target, t, *args)
 
 
 @set_module_as('dendritex')
-def heun3_step(target: DendriteDynamics, t: bst.typing.ArrayLike, *args):
+def heun3_step(target: DiffEqModule, t: bst.typing.ArrayLike, *args):
     _general_rk_step(heun3_tableau, target, t, *args)
 
 
 @set_module_as('dendritex')
-def ssprk3_step(target: DendriteDynamics, t: bst.typing.ArrayLike, *args):
+def ssprk3_step(target: DiffEqModule, t: bst.typing.ArrayLike, *args):
     _general_rk_step(ssprk3_tableau, target, t, *args)
 
 
 @set_module_as('dendritex')
-def ralston3_step(target: DendriteDynamics, t: bst.typing.ArrayLike, *args):
+def ralston3_step(target: DiffEqModule, t: bst.typing.ArrayLike, *args):
     _general_rk_step(ralston3_tableau, target, t, *args)
 
 
 @set_module_as('dendritex')
-def rk4_step(target: DendriteDynamics, t: bst.typing.ArrayLike, *args):
+def rk4_step(target: DiffEqModule, t: bst.typing.ArrayLike, *args):
     _general_rk_step(rk4_tableau, target, t, *args)
 
 
 @set_module_as('dendritex')
-def ralston4_step(target: DendriteDynamics, t: bst.typing.ArrayLike, *args):
+def ralston4_step(target: DiffEqModule, t: bst.typing.ArrayLike, *args):
     _general_rk_step(ralston4_tableau, target, t, *args)

--- a/dendritex/_integrators.py
+++ b/dendritex/_integrators.py
@@ -16,62 +16,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Tuple, Callable, Dict, Union, Sequence
+from typing import Sequence
 
 import brainstate as bst
 import brainunit as u
-import diffrax as dfx
 import jax
 from brainstate._state import record_state_value_write
 
 from ._misc import set_module_as
 
-
-class State4Integral(bst.ShortTermState):
-    """
-    A state that integrates the state of the system to the integral of the state.
-
-    Attributes
-    ----------
-    derivative: The derivative of the state.
-
-    """
-
-    __module__ = 'dendritex'
-
-    # derivative of this state
-    derivative: bst.typing.PyTree
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._derivative = None
-
-    @property
-    def derivative(self):
-        return self._derivative
-
-    @derivative.setter
-    def derivative(self, value):
-        record_state_value_write(self)
-        self._derivative = value
-
-
-class DiffEqModule(bst.mixin.Mixin):
-    __module__ = 'dendritex'
-
-    def pre_integral(self, *args, **kwargs):
-        pass
-
-    def compute_derivative(self, *args, **kwargs):
-        raise NotImplementedError
-
-    def post_integral(self, *args, **kwargs):
-        pass
-
-
 __all__ = [
-    'diffrax_solve_adjoint',
-    'diffrax_solve',
+    'DiffEqState',
+    'DiffEqModule',
     'euler_step',
     'midpoint_step',
     'rk2_step',
@@ -85,313 +41,71 @@ __all__ = [
     'ralston4_step',
 ]
 
-diffrax_solvers = {
-    # explicit RK
-    'euler': dfx.Euler,
-    'revheun': dfx.ReversibleHeun,
-    'heun': dfx.Heun,
-    'midpoint': dfx.Midpoint,
-    'ralston': dfx.Ralston,
-    'bosh3': dfx.Bosh3,
-    'tsit5': dfx.Tsit5,
-    'dopri5': dfx.Dopri5,
-    'dopri8': dfx.Dopri8,
 
-    # implicit RK
-    'ieuler': dfx.ImplicitEuler,
-    'kvaerno3': dfx.Kvaerno3,
-    'kvaerno4': dfx.Kvaerno4,
-    'kvaerno5': dfx.Kvaerno5,
-}
-
-
-def _is_quantity(x):
-    return isinstance(x, u.Quantity)
-
-
-def _diffrax_solve(
-    model: Callable,
-    solver: str,
-    t0: u.Quantity,
-    t1: u.Quantity,
-    dt0: u.Quantity,
-    adjoint: str,
-    saveat: Optional[u.Quantity] = None,
-    savefn: Optional[Callable] = None,
-    args: Tuple[bst.typing.PyTree] = (),
-    rtol: Optional[float] = None,
-    atol: Optional[float] = None,
-    max_steps: int = None,
-):
-    if isinstance(adjoint, str):
-        if adjoint == 'adjoint':
-            adjoint = dfx.BacksolveAdjoint()
-        elif adjoint == 'checkpoint':
-            adjoint = dfx.RecursiveCheckpointAdjoint()
-        elif adjoint == 'direct':
-            adjoint = dfx.DirectAdjoint()
-        else:
-            raise ValueError(f"Unknown adjoint method: {adjoint}. Only support 'checkpoint', 'direct', and 'adjoint'.")
-    elif isinstance(adjoint, dfx.AbstractAdjoint):
-        adjoint = adjoint
-    else:
-        raise ValueError(f"Unknown adjoint method: {adjoint}. Only support 'checkpoint', 'direct', and 'adjoint'.")
-
-    # processing times
-    dt0 = dt0.in_unit(u.ms)
-    t0 = t0.in_unit(u.ms)
-    t1 = t1.in_unit(u.ms)
-    if saveat is not None:
-        saveat = saveat.in_unit(u.ms)
-
-    # stepsize controller
-    if rtol is None and atol is None:
-        stepsize_controller = dfx.ConstantStepSize()
-    else:
-        if rtol is None:
-            rtol = atol
-        if atol is None:
-            atol = rtol
-        stepsize_controller = dfx.PIDController(rtol=rtol, atol=atol)
-
-    # numerical solver
-    if solver not in diffrax_solvers:
-        raise ValueError(f"Unknown solver: {solver}")
-    solver = diffrax_solvers[solver]()
-
-    def model_to_derivative(t, *args):
-        with bst.environ.context(t=t * u.ms):
-            with bst.StateTraceStack() as trace:
-                model(t * u.ms, *args)
-                derivatives = []
-                for st in trace.states:
-                    if isinstance(st, State4Integral):
-                        a = u.get_unit(st.derivative) * u.ms
-                        b = u.get_unit(st.value)
-                        assert a.has_same_dim(b), f'Unit mismatch. Got {a} != {b}'
-                        if isinstance(st.derivative, u.Quantity):
-                            st.derivative = st.derivative.in_unit(u.get_unit(st.value) / u.ms)
-                        derivatives.append(st.derivative)
-                    else:
-                        raise ValueError(f"State {st} is not for integral.")
-                return derivatives
-
-    # stateful function and make jaxpr
-    stateful_fn = bst.compile.StatefulFunction(model_to_derivative).make_jaxpr(0., *args)
-
-    # states
-    states = stateful_fn.get_states()
-
-    def vector_filed(t, state_vals, args):
-        new_state_vals, derivatives = stateful_fn.jaxpr_call(state_vals, t, *args)
-        derivatives = tuple(d.mantissa if isinstance(d, u.Quantity) else d
-                            for d in derivatives)
-        return derivatives
-
-    def save_y(t, state_vals, args):
-        for st, st_val in zip(states, state_vals):
-            st.value = u.Quantity(st_val, unit=st.value.unit) if isinstance(st.value, u.Quantity) else st_val
-        assert callable(savefn), 'savefn must be callable.'
-        rets = savefn(t * u.ms, *args)
-        nonlocal return_units
-        if return_units is None:
-            return_units = jax.tree.map(lambda x: x.unit if isinstance(x, u.Quantity) else None, rets,
-                                        is_leaf=_is_quantity)
-        return jax.tree.map(lambda x: x.mantissa if isinstance(x, u.Quantity) else x, rets, is_leaf=_is_quantity)
-
-    return_units = None
-    if savefn is None:
-        return_units = tuple(st.value.unit if isinstance(st.value, u.Quantity) else None for st in states)
-        if saveat is None:
-            if isinstance(adjoint, dfx.BacksolveAdjoint):
-                raise ValueError('saveat must be specified when using backsolve adjoint.')
-            saveat = dfx.SaveAt(steps=True)
-        else:
-            saveat = dfx.SaveAt(ts=saveat.mantissa, t1=True)
-    else:
-        subsaveat_a = dfx.SubSaveAt(t1=True)
-        if saveat is None:
-            subsaveat_b = dfx.SubSaveAt(steps=True, fn=save_y)
-        else:
-            subsaveat_b = dfx.SubSaveAt(ts=saveat.mantissa, fn=save_y)
-        saveat = dfx.SaveAt(subs=[subsaveat_a, subsaveat_b])
-
-    # solving differential equations
-    sol = dfx.diffeqsolve(
-        dfx.ODETerm(vector_filed),
-        solver,
-        t0=t0.mantissa,
-        t1=t1.mantissa,
-        dt0=dt0.mantissa,
-        y0=tuple((v.value.mantissa if isinstance(v.value, u.Quantity) else v.value) for v in states),
-        args=args,
-        saveat=saveat,
-        adjoint=adjoint,
-        stepsize_controller=stepsize_controller,
-        max_steps=max_steps,
-    )
-    if savefn is None:
-        # assign values back to states
-        for st, st_value in zip(states, sol.ys):
-            st.value = u.Quantity(st_value[-1], unit=st.unit) if isinstance(st, u.Quantity) else st_value[-1]
-        # record solver state
-        return (
-            sol.ts * u.ms,
-            jax.tree.map(
-                lambda y, unit: (u.Quantity(y, unit=unit) if unit is not None else y),
-                sol.ys,
-                return_units
-            ),
-            sol.stats
-        )
-    else:
-        # assign values back to states
-        for st, st_value in zip(states, sol.ys[0]):
-            st.value = u.Quantity(st_value[0], unit=st.unit) if isinstance(st, u.Quantity) else st_value[0]
-        # record solver state
-        return (
-            sol.ts[1] * u.ms,
-            jax.tree.map(
-                lambda y, unit: (u.Quantity(y, unit=unit) if unit is not None else y),
-                sol.ys[1],
-                return_units
-            ),
-            sol.stats
-        )
-
-
-def diffrax_solve_adjoint(
-    model: Callable,
-    solver: str,
-    t0: u.Quantity,
-    t1: u.Quantity,
-    dt0: u.Quantity,
-    saveat: Optional[u.Quantity],
-    savefn: Optional[Callable] = None,
-    args: Tuple[bst.typing.PyTree] = (),
-    rtol: Optional[float] = None,
-    atol: Optional[float] = None,
-    max_steps: Optional[int] = None,
-):
+class DiffEqState(bst.ShortTermState):
     """
-    Solve the differential equations using `diffrax <https://docs.kidger.site/diffrax>`_ which
-    is compatible with the adjoint backpropagation.
+    A state that integrates the state of the system to the integral of the state.
 
-    Args:
-      model: The model function to solve.
-      solver: The solver to use. Available solvers are:
-        - 'euler'
-        - 'revheun'
-        - 'heun'
-        - 'midpoint'
-        - 'ralston'
-        - 'bosh3'
-        - 'tsit5'
-        - 'dopri5'
-        - 'dopri8'
-        - 'ieuler'
-        - 'kvaerno3'
-        - 'kvaerno4'
-        - 'kvaerno5'
-      t0: The initial time.
-      t1: The final time.
-      dt0: The initial step size.
-      saveat: The time points to save the solution. If None, save the solution at every step.
-      savefn: The function to save the solution. If None, save the solution at every step.
-      args: The arguments to pass to the model function.
-      rtol: The relative tolerance.
-      atol: The absolute tolerance.
-      max_steps: The maximum number of steps.
+    Attributes
+    ----------
+    derivative: The derivative of the differential equation state.
+    diffusion: The diffusion of the differential equation state.
 
-    Returns:
-      The solution of the differential equations, including the following items:
-        - The time points.
-        - The solution.
-        - The running step statistics.
     """
-    return _diffrax_solve(
-        model=model,
-        solver=solver,
-        t0=t0,
-        t1=t1,
-        dt0=dt0,
-        saveat=saveat,
-        savefn=savefn,
-        adjoint='adjoint',
-        max_steps=max_steps,
-        args=args,
-        rtol=rtol,
-        atol=atol,
-    )
+
+    __module__ = 'dendritex'
+
+    # derivative of this state
+    derivative: bst.typing.PyTree
+    diffusion: bst.typing.PyTree
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._derivative = None
+        self._diffusion = None
+
+    @property
+    def derivative(self):
+        """
+        The derivative of the state.
+
+        It is used to compute the derivative of the ODE system,
+        or the drift of the SDE system.
+        """
+        return self._derivative
+
+    @derivative.setter
+    def derivative(self, value):
+        record_state_value_write(self)
+        self._derivative = value
+
+    @property
+    def diffusion(self):
+        """
+        The diffusion of the state.
+
+        It is used to compute the diffusion of the SDE system.
+        If it is None, the system is considered as an ODE system.
+        """
+        return self._diffusion
+
+    @diffusion.setter
+    def diffusion(self, value):
+        record_state_value_write(self)
+        self._diffusion = value
 
 
-def diffrax_solve(
-    model: Callable,
-    solver: str,
-    t0: u.Quantity,
-    t1: u.Quantity,
-    dt0: u.Quantity,
-    saveat: Optional[u.Quantity] = None,
-    savefn: Optional[Callable] = None,
-    args: Tuple[bst.typing.PyTree] = (),
-    rtol: Optional[float] = None,
-    atol: Optional[float] = None,
-    max_steps: Optional[int] = None,
-    adjoint: Union[str, dfx.AbstractAdjoint] = 'checkpoint',
-) -> Tuple[u.Quantity, bst.typing.PyTree[u.Quantity], Dict]:
-    """
-    Solve the differential equations using `diffrax <https://docs.kidger.site/diffrax>`_.
+class DiffEqModule(bst.mixin.Mixin):
+    __module__ = 'dendritex'
 
-    Args:
-      model: The model function to solve.
-      solver: The solver to use. Available solvers are:
-        - 'euler'
-        - 'revheun'
-        - 'heun'
-        - 'midpoint'
-        - 'ralston'
-        - 'bosh3'
-        - 'tsit5'
-        - 'dopri5'
-        - 'dopri8'
-        - 'ieuler'
-        - 'kvaerno3'
-        - 'kvaerno4'
-        - 'kvaerno5'
-      t0: The initial time.
-      t1: The final time.
-      dt0: The initial step size.
-      saveat: The time points to save the solution. If None, save the solution at every step.
-      savefn: The function to save the solution. If None, save the solution at every step.
-      args: The arguments to pass to the model function.
-      rtol: The relative tolerance.
-      atol: The absolute tolerance.
-      max_steps: The maximum number of steps.
-      adjoint: The adjoint method. Available methods are:
-        - 'adjoint'
-        - 'checkpoint'
-        - 'direct'
+    def pre_integral(self, *args, **kwargs):
+        pass
 
-    Returns:
-      The solution of the differential equations, including the following items:
-        - The time points.
-        - The solution.
-        - The running step statistics.
-    """
-    return _diffrax_solve(
-        model=model,
-        solver=solver,
-        t0=t0,
-        t1=t1,
-        dt0=dt0,
-        saveat=saveat,
-        savefn=savefn,
-        adjoint=adjoint,
-        args=args,
-        rtol=rtol,
-        atol=atol,
-        max_steps=max_steps,
-    )
+    def compute_derivative(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def post_integral(self, *args, **kwargs):
+        pass
 
 
 @dataclass(frozen=True)
@@ -430,40 +144,38 @@ def _general_rk_step(
 ):
     dt = bst.environ.get_dt()
 
-    # Runge-Kutta stages
-    ks = []
-
     # before one-step integration
     target.pre_integral(*args)
 
+    # Runge-Kutta stages
+    ks = []
+
     # k1: first derivative step
     assert len(tableau.A[0]) == 0, f'The first row of A must be empty. Got {tableau.A[0]}'
-    with bst.environ.context(t=t + tableau.C[0] * dt):
-        with bst.StateTraceStack() as trace:
-            # compute derivative
-            target.compute_derivative(*args)
+    with bst.environ.context(t=t + tableau.C[0] * dt), bst.StateTraceStack() as trace:
+        # compute derivative
+        target.compute_derivative(*args)
 
-            # collection of states, initial values, and derivatives
-            states = []  # states
-            k1hs = []  # k1hs: k1 holder
-            y0 = []  # initial values
-            for st, val, writen in zip(trace.states, trace.original_state_values, trace.been_writen):
-                if isinstance(st, State4Integral):
-                    assert writen, f'State {st} must be written.'
-                    y0.append(val)
-                    states.append(st)
-                    k1hs.append(st.derivative)
-                else:
-                    if writen:
-                        raise ValueError(f'State {st} is not for integral.')
-            ks.append(k1hs)
+        # collection of states, initial values, and derivatives
+        states = []  # states
+        k1hs = []  # k1hs: k1 holder
+        y0 = []  # initial values
+        for st, val, writen in zip(trace.states, trace.original_state_values, trace.been_writen):
+            if isinstance(st, DiffEqState):
+                assert writen, f'State {st} must be written.'
+                y0.append(val)
+                states.append(st)
+                k1hs.append(st.derivative)
+            else:
+                if writen:
+                    raise ValueError(f'State {st} is not for integral.')
+        ks.append(k1hs)
 
     # intermediate steps
     for i in range(1, len(tableau.C)):
-        with bst.environ.context(t=t + tableau.C[i] * dt):
-            with bst.check_state_value_tree():
-                for st, y0_, *ks_ in zip(states, y0, *ks):
-                    _rk_update(tableau.A[i], st, y0_, *ks_)
+        with bst.environ.context(t=t + tableau.C[i] * dt), bst.check_state_value_tree():
+            for st, y0_, *ks_ in zip(states, y0, *ks):
+                _rk_update(tableau.A[i], st, y0_, *ks_)
             target.compute_derivative(*args)
             ks.append([st.derivative for st in states])
 

--- a/dendritex/_integrators.py
+++ b/dendritex/_integrators.py
@@ -15,8 +15,9 @@
 
 from __future__ import annotations
 
+import importlib.util
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Optional, Tuple, Callable, Dict, Union, Sequence
 
 import brainstate as bst
 import brainunit as u
@@ -25,7 +26,32 @@ from brainstate._state import record_state_value_write
 
 from ._misc import set_module_as
 
+diffrax_installed = importlib.util.find_spec('diffrax') is not None
+if diffrax_installed:
+    import diffrax as dfx
+
+    diffrax_solvers = {
+        # explicit RK
+        'euler': dfx.Euler,
+        'revheun': dfx.ReversibleHeun,
+        'heun': dfx.Heun,
+        'midpoint': dfx.Midpoint,
+        'ralston': dfx.Ralston,
+        'bosh3': dfx.Bosh3,
+        'tsit5': dfx.Tsit5,
+        'dopri5': dfx.Dopri5,
+        'dopri8': dfx.Dopri8,
+
+        # implicit RK
+        'ieuler': dfx.ImplicitEuler,
+        'kvaerno3': dfx.Kvaerno3,
+        'kvaerno4': dfx.Kvaerno4,
+        'kvaerno5': dfx.Kvaerno5,
+    }
+
 __all__ = [
+    'diffrax_solve_adjoint',
+    'diffrax_solve',
     'DiffEqState',
     'DiffEqModule',
     'euler_step',
@@ -106,6 +132,298 @@ class DiffEqModule(bst.mixin.Mixin):
 
     def post_integral(self, *args, **kwargs):
         pass
+
+
+def _is_quantity(x):
+    return isinstance(x, u.Quantity)
+
+
+def _diffrax_solve(
+    model: Callable,
+    solver: str,
+    t0: u.Quantity,
+    t1: u.Quantity,
+    dt0: u.Quantity,
+    adjoint: str,
+    saveat: Optional[u.Quantity] = None,
+    savefn: Optional[Callable] = None,
+    args: Tuple[bst.typing.PyTree] = (),
+    rtol: Optional[float] = None,
+    atol: Optional[float] = None,
+    max_steps: int = None,
+):
+    if diffrax_installed is False:
+        raise ImportError('diffrax is not installed. Please install it via `pip install diffrax`.')
+
+    if isinstance(adjoint, str):
+        if adjoint == 'adjoint':
+            adjoint = dfx.BacksolveAdjoint()
+        elif adjoint == 'checkpoint':
+            adjoint = dfx.RecursiveCheckpointAdjoint()
+        elif adjoint == 'direct':
+            adjoint = dfx.DirectAdjoint()
+        else:
+            raise ValueError(f"Unknown adjoint method: {adjoint}. Only support 'checkpoint', 'direct', and 'adjoint'.")
+    elif isinstance(adjoint, dfx.AbstractAdjoint):
+        adjoint = adjoint
+    else:
+        raise ValueError(f"Unknown adjoint method: {adjoint}. Only support 'checkpoint', 'direct', and 'adjoint'.")
+
+    # processing times
+    dt0 = dt0.in_unit(u.ms)
+    t0 = t0.in_unit(u.ms)
+    t1 = t1.in_unit(u.ms)
+    if saveat is not None:
+        saveat = saveat.in_unit(u.ms)
+
+    # stepsize controller
+    if rtol is None and atol is None:
+        stepsize_controller = dfx.ConstantStepSize()
+    else:
+        if rtol is None:
+            rtol = atol
+        if atol is None:
+            atol = rtol
+        stepsize_controller = dfx.PIDController(rtol=rtol, atol=atol)
+
+    # numerical solver
+    if solver not in diffrax_solvers:
+        raise ValueError(f"Unknown solver: {solver}")
+    solver = diffrax_solvers[solver]()
+
+    def model_to_derivative(t, *args):
+        with bst.environ.context(t=t * u.ms):
+            with bst.StateTraceStack() as trace:
+                model(t * u.ms, *args)
+                derivatives = []
+                for st in trace.states:
+                    if isinstance(st, DiffEqState):
+                        a = u.get_unit(st.derivative) * u.ms
+                        b = u.get_unit(st.value)
+                        assert a.has_same_dim(b), f'Unit mismatch. Got {a} != {b}'
+                        if isinstance(st.derivative, u.Quantity):
+                            st.derivative = st.derivative.in_unit(u.get_unit(st.value) / u.ms)
+                        derivatives.append(st.derivative)
+                    else:
+                        raise ValueError(f"State {st} is not for integral.")
+                return derivatives
+
+    # stateful function and make jaxpr
+    stateful_fn = bst.compile.StatefulFunction(model_to_derivative).make_jaxpr(0., *args)
+
+    # states
+    states = stateful_fn.get_states()
+
+    def vector_filed(t, state_vals, args):
+        new_state_vals, derivatives = stateful_fn.jaxpr_call(state_vals, t, *args)
+        derivatives = tuple(d.mantissa if isinstance(d, u.Quantity) else d
+                            for d in derivatives)
+        return derivatives
+
+    def save_y(t, state_vals, args):
+        for st, st_val in zip(states, state_vals):
+            st.value = u.Quantity(st_val, unit=st.value.unit) if isinstance(st.value, u.Quantity) else st_val
+        assert callable(savefn), 'savefn must be callable.'
+        rets = savefn(t * u.ms, *args)
+        nonlocal return_units
+        if return_units is None:
+            return_units = jax.tree.map(lambda x: x.unit if isinstance(x, u.Quantity) else None, rets,
+                                        is_leaf=_is_quantity)
+        return jax.tree.map(lambda x: x.mantissa if isinstance(x, u.Quantity) else x, rets, is_leaf=_is_quantity)
+
+    return_units = None
+    if savefn is None:
+        return_units = tuple(st.value.unit if isinstance(st.value, u.Quantity) else None for st in states)
+        if saveat is None:
+            if isinstance(adjoint, dfx.BacksolveAdjoint):
+                raise ValueError('saveat must be specified when using backsolve adjoint.')
+            saveat = dfx.SaveAt(steps=True)
+        else:
+            saveat = dfx.SaveAt(ts=saveat.mantissa, t1=True)
+    else:
+        subsaveat_a = dfx.SubSaveAt(t1=True)
+        if saveat is None:
+            subsaveat_b = dfx.SubSaveAt(steps=True, fn=save_y)
+        else:
+            subsaveat_b = dfx.SubSaveAt(ts=saveat.mantissa, fn=save_y)
+        saveat = dfx.SaveAt(subs=[subsaveat_a, subsaveat_b])
+
+    # solving differential equations
+    sol = dfx.diffeqsolve(
+        dfx.ODETerm(vector_filed),
+        solver,
+        t0=t0.mantissa,
+        t1=t1.mantissa,
+        dt0=dt0.mantissa,
+        y0=tuple((v.value.mantissa if isinstance(v.value, u.Quantity) else v.value) for v in states),
+        args=args,
+        saveat=saveat,
+        adjoint=adjoint,
+        stepsize_controller=stepsize_controller,
+        max_steps=max_steps,
+    )
+    if savefn is None:
+        # assign values back to states
+        for st, st_value in zip(states, sol.ys):
+            st.value = u.Quantity(st_value[-1], unit=st.unit) if isinstance(st, u.Quantity) else st_value[-1]
+        # record solver state
+        return (
+            sol.ts * u.ms,
+            jax.tree.map(
+                lambda y, unit: (u.Quantity(y, unit=unit) if unit is not None else y),
+                sol.ys,
+                return_units
+            ),
+            sol.stats
+        )
+    else:
+        # assign values back to states
+        for st, st_value in zip(states, sol.ys[0]):
+            st.value = u.Quantity(st_value[0], unit=st.unit) if isinstance(st, u.Quantity) else st_value[0]
+        # record solver state
+        return (
+            sol.ts[1] * u.ms,
+            jax.tree.map(
+                lambda y, unit: (u.Quantity(y, unit=unit) if unit is not None else y),
+                sol.ys[1],
+                return_units
+            ),
+            sol.stats
+        )
+
+
+def diffrax_solve_adjoint(
+    model: Callable,
+    solver: str,
+    t0: u.Quantity,
+    t1: u.Quantity,
+    dt0: u.Quantity,
+    saveat: Optional[u.Quantity],
+    savefn: Optional[Callable] = None,
+    args: Tuple[bst.typing.PyTree] = (),
+    rtol: Optional[float] = None,
+    atol: Optional[float] = None,
+    max_steps: Optional[int] = None,
+):
+    """
+    Solve the differential equations using `diffrax <https://docs.kidger.site/diffrax>`_ which
+    is compatible with the adjoint backpropagation.
+
+    Args:
+      model: The model function to solve.
+      solver: The solver to use. Available solvers are:
+        - 'euler'
+        - 'revheun'
+        - 'heun'
+        - 'midpoint'
+        - 'ralston'
+        - 'bosh3'
+        - 'tsit5'
+        - 'dopri5'
+        - 'dopri8'
+        - 'ieuler'
+        - 'kvaerno3'
+        - 'kvaerno4'
+        - 'kvaerno5'
+      t0: The initial time.
+      t1: The final time.
+      dt0: The initial step size.
+      saveat: The time points to save the solution. If None, save the solution at every step.
+      savefn: The function to save the solution. If None, save the solution at every step.
+      args: The arguments to pass to the model function.
+      rtol: The relative tolerance.
+      atol: The absolute tolerance.
+      max_steps: The maximum number of steps.
+
+    Returns:
+      The solution of the differential equations, including the following items:
+        - The time points.
+        - The solution.
+        - The running step statistics.
+    """
+    return _diffrax_solve(
+        model=model,
+        solver=solver,
+        t0=t0,
+        t1=t1,
+        dt0=dt0,
+        saveat=saveat,
+        savefn=savefn,
+        adjoint='adjoint',
+        max_steps=max_steps,
+        args=args,
+        rtol=rtol,
+        atol=atol,
+    )
+
+
+def diffrax_solve(
+    model: Callable,
+    solver: str,
+    t0: u.Quantity,
+    t1: u.Quantity,
+    dt0: u.Quantity,
+    saveat: Optional[u.Quantity] = None,
+    savefn: Optional[Callable] = None,
+    args: Tuple[bst.typing.PyTree] = (),
+    rtol: Optional[float] = None,
+    atol: Optional[float] = None,
+    max_steps: Optional[int] = None,
+    adjoint: Union[str, dfx.AbstractAdjoint] = 'checkpoint',
+) -> Tuple[u.Quantity, bst.typing.PyTree[u.Quantity], Dict]:
+    """
+    Solve the differential equations using `diffrax <https://docs.kidger.site/diffrax>`_.
+
+    Args:
+      model: The model function to solve.
+      solver: The solver to use. Available solvers are:
+        - 'euler'
+        - 'revheun'
+        - 'heun'
+        - 'midpoint'
+        - 'ralston'
+        - 'bosh3'
+        - 'tsit5'
+        - 'dopri5'
+        - 'dopri8'
+        - 'ieuler'
+        - 'kvaerno3'
+        - 'kvaerno4'
+        - 'kvaerno5'
+      t0: The initial time.
+      t1: The final time.
+      dt0: The initial step size.
+      saveat: The time points to save the solution. If None, save the solution at every step.
+      savefn: The function to save the solution. If None, save the solution at every step.
+      args: The arguments to pass to the model function.
+      rtol: The relative tolerance.
+      atol: The absolute tolerance.
+      max_steps: The maximum number of steps.
+      adjoint: The adjoint method. Available methods are:
+        - 'adjoint'
+        - 'checkpoint'
+        - 'direct'
+
+    Returns:
+      The solution of the differential equations, including the following items:
+        - The time points.
+        - The solution.
+        - The running step statistics.
+    """
+    return _diffrax_solve(
+        model=model,
+        solver=solver,
+        t0=t0,
+        t1=t1,
+        dt0=dt0,
+        saveat=saveat,
+        savefn=savefn,
+        adjoint=adjoint,
+        args=args,
+        rtol=rtol,
+        atol=atol,
+        max_steps=max_steps,
+    )
 
 
 @dataclass(frozen=True)

--- a/dendritex/_misc.py
+++ b/dendritex/_misc.py
@@ -65,10 +65,7 @@ class Container(bst.mixin.Mixin):
         children = super().__getattribute__(name)
         if item == name:
             return children
-        if item in children:
-            return children[item]
-        else:
-            return super().__getattribute__(item)
+        return children[item] if item in children else super().__getattribute__(item)
 
     def add_elem(self, *elems, **elements):
         """

--- a/dendritex/_misc.py
+++ b/dendritex/_misc.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 
+from __future__ import annotations
+
+from typing import Callable
+
+import brainstate as bst
+
 
 def set_module_as(name: str):
     def decorator(module):
@@ -20,3 +26,92 @@ def set_module_as(name: str):
         return module
 
     return decorator
+
+
+class Container(bst.mixin.Mixin):
+    __module__ = 'dendritex'
+
+    _container_name: str
+
+    @staticmethod
+    def _format_elements(child_type: type, **children_as_dict):
+        res = dict()
+
+        # add dict-typed components
+        for k, v in children_as_dict.items():
+            if not isinstance(v, child_type):
+                raise TypeError(f'Should be instance of {child_type.__name__}. '
+                                f'But we got {type(v)}')
+            res[k] = v
+        return res
+
+    def __getitem__(self, item):
+        """
+        Overwrite the slice access (`self['']`).
+        """
+        children = self.__getattr__(self._container_name)
+        if item in children:
+            return children[item]
+        else:
+            raise ValueError(f'Unknown item {item}, we only found {list(children.keys())}')
+
+    def __getattr__(self, item):
+        """
+        Overwrite the dot access (`self.`).
+        """
+        name = super().__getattribute__('_container_name')
+        if item == '_container_name':
+            return name
+        children = super().__getattribute__(name)
+        if item == name:
+            return children
+        if item in children:
+            return children[item]
+        else:
+            return super().__getattribute__(item)
+
+    def add_elem(self, *elems, **elements):
+        """
+        Add new elements.
+
+        Args:
+          elements: children objects.
+        """
+        raise NotImplementedError('Must be implemented by the subclass.')
+
+
+class TreeNode(bst.mixin.Mixin):
+    __module__ = 'dendritex'
+
+    root_type: type
+
+    @staticmethod
+    def _root_leaf_pair_check(root: type, leaf: 'TreeNode'):
+        if hasattr(leaf, 'root_type'):
+            root_type = leaf.root_type
+        else:
+            raise ValueError('Child class should define "root_type" to '
+                             'specify the type of the root node. '
+                             f'But we did not found it in {leaf}')
+        if not issubclass(root, root_type):
+            raise TypeError(f'Type does not match. {leaf} requires a root with type '
+                            f'of {leaf.root_type}, but the root now is {root}.')
+
+    @staticmethod
+    def check_hierarchies(root: type, *leaves, check_fun: Callable = None, **named_leaves):
+        if check_fun is None:
+            check_fun = TreeNode._root_leaf_pair_check
+
+        for leaf in leaves:
+            if isinstance(leaf, bst.graph.Node):
+                check_fun(root, leaf)
+            elif isinstance(leaf, (list, tuple)):
+                TreeNode.check_hierarchies(root, *leaf, check_fun=check_fun)
+            elif isinstance(leaf, dict):
+                TreeNode.check_hierarchies(root, **leaf, check_fun=check_fun)
+            else:
+                raise ValueError(f'Do not support {type(leaf)}.')
+        for leaf in named_leaves.values():
+            if not isinstance(leaf, bst.graph.Node):
+                raise ValueError(f'Do not support {type(leaf)}. Must be instance of {bst.graph.Node}')
+            check_fun(root, leaf)

--- a/dendritex/_misc.py
+++ b/dendritex/_misc.py
@@ -35,7 +35,7 @@ class Container(bst.mixin.Mixin):
 
     @staticmethod
     def _format_elements(child_type: type, **children_as_dict):
-        res = dict()
+        res = {}
 
         # add dict-typed components
         for k, v in children_as_dict.items():

--- a/dendritex/channels/calcium.py
+++ b/dendritex/channels/calcium.py
@@ -13,7 +13,7 @@ import brainstate as bst
 import brainunit as u
 
 from dendritex._base import Channel, IonInfo
-from dendritex._integrators import State4Integral
+from dendritex._integrators import DiffEqState
 from dendritex.ions import Calcium
 
 __all__ = [
@@ -114,7 +114,7 @@ class ICaN_IS2008(CalciumChannel):
         self.phi = bst.init.param(phi, self.varshape, allow_none=False)
 
     def init_state(self, V, Ca: IonInfo, batch_size: int = None):
-        self.p = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, Ca, batch_size=None):
         V = V.to_decimal(u.mV)
@@ -177,8 +177,8 @@ class _ICa_p2q_ss(CalciumChannel):
         self.g_max = bst.init.param(g_max, self.varshape, allow_none=False)
 
     def init_state(self, V, Ca: IonInfo, batch_size: int = None):
-        self.p = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.q = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.q = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, Ca, batch_size=None):
         self.p.value = self.f_p_inf(V)
@@ -252,8 +252,8 @@ class _ICa_p2q_markov(CalciumChannel):
         self.g_max = bst.init.param(g_max, self.varshape, allow_none=False)
 
     def init_state(self, V, Ca: IonInfo, batch_size: int = None):
-        self.p = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.q = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.q = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, Ca, batch_size=None):
         alpha, beta = self.f_p_alpha(V), self.f_p_beta(V)
@@ -786,9 +786,9 @@ class ICav12_Ma2020(CalciumChannel):
         self.VDI = 0.17
 
     def init_state(self, V, Ca: IonInfo, batch_size: int = None):
-        self.m = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.h = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.n = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.m = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.h = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.n = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, Ca, batch_size=None):
         self.m.value = self.f_m_inf(V)
@@ -859,9 +859,9 @@ class ICav13_Ma2020(CalciumChannel):
         self.VDI = 1
 
     def init_state(self, V, Ca: IonInfo, batch_size: int = None):
-        self.m = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.h = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.n = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.m = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.h = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.n = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, Ca, batch_size=None):
         self.m.value = self.f_m_inf(V)
@@ -938,8 +938,8 @@ class ICav23_Ma2020(CalciumChannel):
         self.eca = 140 * u.mV
 
     def init_state(self, V, Ca: IonInfo, batch_size: int = None):
-        self.m = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.h = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.m = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.h = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, Ca, batch_size=None):
         self.m.value = self.f_m_inf(V)
@@ -1023,8 +1023,8 @@ class ICav31_Ma2020(CalciumChannel):
         self.z = 2
 
     def init_state(self, V, Ca: IonInfo, batch_size: int = None):
-        self.p = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.q = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.q = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, Ca, batch_size=None):
         self.p.value = self.f_p_inf(V)
@@ -1117,8 +1117,8 @@ class ICaGrc_Ma2020(CalciumChannel):
         self.V0beta_u = -48
 
     def init_state(self, V, Ca: IonInfo, batch_size: int = None):
-        self.m = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.h = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.m = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.h = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, Ca, batch_size=None):
         self.m.value = self.f_m_inf(V)

--- a/dendritex/channels/calcium.py
+++ b/dendritex/channels/calcium.py
@@ -12,7 +12,8 @@ from typing import Union, Callable, Optional
 import brainstate as bst
 import brainunit as u
 
-from dendritex._base import Channel, IonInfo, State4Integral
+from dendritex._base import Channel, IonInfo
+from dendritex._integrators import State4Integral
 from dendritex.ions import Calcium
 
 __all__ = [
@@ -39,10 +40,10 @@ class CalciumChannel(Channel):
 
     root_type = Calcium
 
-    def before_integral(self, V, Ca: IonInfo):
+    def pre_integral(self, V, Ca: IonInfo):
         pass
 
-    def post_derivative(self, V, Ca: IonInfo):
+    def post_integral(self, V, Ca: IonInfo):
         pass
 
     def compute_derivative(self, V, Ca: IonInfo):

--- a/dendritex/channels/hyperpolarization_activated.py
+++ b/dendritex/channels/hyperpolarization_activated.py
@@ -11,7 +11,8 @@ from typing import Union, Callable, Optional
 import brainstate as bst
 import brainunit as bu
 
-from dendritex._base import Channel, HHTypedNeuron, State4Integral
+from dendritex._base import Channel, HHTypedNeuron
+from dendritex._integrators import State4Integral
 
 __all__ = [
     'Ih_HM1992',
@@ -79,13 +80,13 @@ class Ih_HM1992(Channel):
     def reset_state(self, V, batch_size=None):
         self.p.value = self.f_p_inf(V)
 
-    def before_integral(self, V):
+    def pre_integral(self, V):
         pass
 
     def compute_derivative(self, V):
         self.p.derivative = self.phi * (self.f_p_inf(V) - self.p.value) / self.f_p_tau(V) / bu.ms
 
-    def post_derivative(self, V):
+    def post_integral(self, V):
         pass
 
     def current(self, V):
@@ -302,14 +303,14 @@ class Ih1_Ma2020(Channel):
         self.p.value = self.f_p_inf(V)
         self.q.value = self.f_q_inf(V)
 
-    def before_integral(self, V):
+    def pre_integral(self, V):
         pass
 
     def compute_derivative(self, V):
         self.p.derivative = self.phi_channel * (self.f_p_inf(V) - self.p.value) / self.f_p_tau(V) / bu.ms
         self.q.derivative = self.phi_channel * (self.f_q_inf(V) - self.q.value) / self.f_q_tau(V) / bu.ms
 
-    def post_derivative(self, V):
+    def post_integral(self, V):
         pass
 
     def current(self, V):
@@ -391,14 +392,14 @@ class Ih2_Ma2020(Channel):
         self.p.value = self.f_p_inf(V)
         self.q.value = self.f_q_inf(V)
 
-    def before_integral(self, V):
+    def pre_integral(self, V):
         pass
 
     def compute_derivative(self, V):
         self.p.derivative = self.phi_channel * (self.f_p_inf(V) - self.p.value) / self.f_p_tau(V) / bu.ms
         self.q.derivative = self.phi_channel * (self.f_q_inf(V) - self.q.value) / self.f_q_tau(V) / bu.ms
 
-    def post_derivative(self, V):
+    def post_integral(self, V):
         pass
 
     def current(self, V):

--- a/dendritex/channels/hyperpolarization_activated.py
+++ b/dendritex/channels/hyperpolarization_activated.py
@@ -12,7 +12,7 @@ import brainstate as bst
 import brainunit as bu
 
 from dendritex._base import Channel, HHTypedNeuron
-from dendritex._integrators import State4Integral
+from dendritex._integrators import DiffEqState
 
 __all__ = [
     'Ih_HM1992',
@@ -75,7 +75,7 @@ class Ih_HM1992(Channel):
         self.E = bst.init.param(E, self.varshape, allow_none=False)
 
     def init_state(self, V, batch_size=None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, batch_size=None):
         self.p.value = self.f_p_inf(V)
@@ -218,9 +218,9 @@ class Ih_HM1992(Channel):
 #     return self.g_max * (self.O.value + self.g_inc * self.OL.value) * (self.E - V)
 #
 #   def init_state(self, V, Ca, batch_size=None):
-#     self.O = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-#     self.OL = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-#     self.P1 = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
+#     self.O = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+#     self.OL = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+#     self.P1 = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
 #
 #   def reset_state(self, V, Ca: IonInfo, batch_size=None):
 #     varshape = self.varshape if (batch_size is None) else ((batch_size,) + self.varshape)
@@ -296,8 +296,8 @@ class Ih1_Ma2020(Channel):
         self.tEs = 2.302585092
 
     def init_state(self, V, batch_size=None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
-        self.q = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.q = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, batch_size=None):
         self.p.value = self.f_p_inf(V)
@@ -385,8 +385,8 @@ class Ih2_Ma2020(Channel):
         self.tEs = 2.3026
 
     def init_state(self, V, batch_size=None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
-        self.q = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.q = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, batch_size=None):
         self.p.value = self.f_p_inf(V)

--- a/dendritex/channels/leaky.py
+++ b/dendritex/channels/leaky.py
@@ -28,10 +28,10 @@ class LeakageChannel(Channel):
 
     root_type = HHTypedNeuron
 
-    def before_integral(self, V):
+    def pre_integral(self, V):
         pass
 
-    def post_derivative(self, V):
+    def post_integral(self, V):
         pass
 
     def compute_derivative(self, V):

--- a/dendritex/channels/potassium.py
+++ b/dendritex/channels/potassium.py
@@ -13,7 +13,7 @@ import brainstate as bst
 import brainunit as bu
 
 from dendritex._base import Channel, IonInfo
-from dendritex._integrators import State4Integral
+from dendritex._integrators import DiffEqState
 from dendritex.ions import Potassium
 
 __all__ = [
@@ -101,7 +101,7 @@ class _IK_p4_markov(PotassiumChannel):
         self.phi = bst.init.param(phi, self.varshape, allow_none=False)
 
     def init_state(self, V, K: IonInfo, batch_size=None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, K: IonInfo, batch_size: int = None):
         alpha = self.f_p_alpha(V)
@@ -387,8 +387,8 @@ class _IKA_p4q_ss(PotassiumChannel):
         return self.g_max * self.p.value ** 4 * self.q.value * (K.E - V)
 
     def init_state(self, V, K: IonInfo, batch_size: int = None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
-        self.q = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.q = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, K: IonInfo, batch_size=None):
         self.p.value = self.f_p_inf(V)
@@ -654,8 +654,8 @@ class _IKK2_pq_ss(PotassiumChannel):
         return self.g_max * self.p.value * self.q.value * (K.E - V)
 
     def init_state(self, V, Ca: IonInfo, batch_size: int = None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
-        self.q = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.q = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, K: IonInfo, batch_size=None):
         self.p.value = self.f_p_inf(V)
@@ -916,7 +916,7 @@ class IKNI_Ya1989(PotassiumChannel):
         return self.g_max * self.p.value * (K.E - V)
 
     def init_state(self, V, Ca: IonInfo, batch_size: int = None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, K: IonInfo, batch_size=None):
         self.p.value = self.f_p_inf(V)
@@ -1033,7 +1033,7 @@ class IKv11_Ak2007(PotassiumChannel):
         self.zn = 2.7978
 
     def init_state(self, V, K: IonInfo, batch_size=None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, K: IonInfo, batch_size: int = None):
         alpha = self.f_p_alpha(V)
@@ -1112,8 +1112,8 @@ class IKv34_Ma2020(PotassiumChannel):
         return self.g_max * self.p.value ** 3 * self.q.value * (K.E - V)
 
     def init_state(self, V, K: IonInfo, batch_size: int = None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
-        self.q = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.q = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, K: IonInfo, batch_size=None):
         self.p.value = self.f_p_inf(V)
@@ -1209,8 +1209,8 @@ class IKv43_Ma2020(PotassiumChannel):
         return self.g_max * self.p.value ** 3 * self.q.value * (K.E - V)
 
     def init_state(self, V, K: IonInfo, batch_size: int = None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
-        self.q = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.q = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, K: IonInfo, batch_size=None):
         self.p.value = self.f_p_inf(V)
@@ -1304,7 +1304,7 @@ class IKM_Grc_Ma2020(PotassiumChannel):
         return self.g_max * self.p.value * (self.ek - V)
 
     def init_state(self, V, K: IonInfo, batch_size: int = None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, K: IonInfo, batch_size=None):
         self.p.value = self.f_p_inf(V)

--- a/dendritex/channels/potassium.py
+++ b/dendritex/channels/potassium.py
@@ -12,7 +12,8 @@ from typing import Union, Callable, Optional, Sequence
 import brainstate as bst
 import brainunit as bu
 
-from dendritex._base import Channel, IonInfo, State4Integral
+from dendritex._base import Channel, IonInfo
+from dendritex._integrators import State4Integral
 from dendritex.ions import Potassium
 
 __all__ = [
@@ -40,10 +41,10 @@ class PotassiumChannel(Channel):
 
     root_type = Potassium
 
-    def before_integral(self, V, K: IonInfo):
+    def pre_integral(self, V, K: IonInfo):
         pass
 
-    def post_derivative(self, V, K: IonInfo):
+    def post_integral(self, V, K: IonInfo):
         pass
 
     def compute_derivative(self, V, K: IonInfo):
@@ -1043,7 +1044,7 @@ class IKv11_Ak2007(PotassiumChannel):
 
     def compute_derivative(self, V, K: IonInfo):
         self.p.derivative = self.phi * (
-                self.f_p_alpha(V) * (1. - self.p.value) - self.f_p_beta(V) * self.p.value) / bu.ms
+            self.f_p_alpha(V) * (1. - self.p.value) - self.f_p_beta(V) * self.p.value) / bu.ms
 
     def current(self, V, K: IonInfo):
         if self.gateCurrent == 0:

--- a/dendritex/channels/potassium_calcium.py
+++ b/dendritex/channels/potassium_calcium.py
@@ -14,7 +14,7 @@ import brainunit as bu
 import jax
 
 from dendritex._base import IonInfo, Channel
-from dendritex._integrators import State4Integral
+from dendritex._integrators import DiffEqState
 from dendritex.ions import Calcium, Potassium
 
 __all__ = [
@@ -127,7 +127,7 @@ class IAHP_De1994(KCaChannel):
         return self.g_max * self.p.value * self.p.value * (K.E - V)
 
     def init_state(self, V, K: IonInfo, Ca: IonInfo, batch_size=None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, K: IonInfo, Ca: IonInfo, batch_size=None):
         C2 = self.alpha * bu.math.power(Ca.C / bu.mM, self.n)
@@ -193,7 +193,7 @@ class IKca3_1_Ma2020(KCaChannel):
         return bu.math.where(Ca.C / bu.mM < 0.01, concdep_1, concdep_2)
 
     def init_state(self, V, K: IonInfo, Ca: IonInfo, batch_size=None):
-        self.p = State4Integral(bst.init.param(bu.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(bu.math.zeros, self.varshape, batch_size))
         self.reset_state(V, K, Ca)
 
     def reset_state(self, V, K: IonInfo, Ca: IonInfo, batch_size=None):
@@ -257,12 +257,12 @@ class IKca2_2_Ma2020(KCaChannel):
 
     def init_state(self, V, K: IonInfo, Ca: IonInfo, batch_size=None):
 
-        self.C1 = State4Integral(bst.init.param(bu.math.ones, self.varshape, batch_size))
-        self.C2 = State4Integral(bst.init.param(bu.math.ones, self.varshape, batch_size))
-        self.C3 = State4Integral(bst.init.param(bu.math.ones, self.varshape, batch_size))
-        self.C4 = State4Integral(bst.init.param(bu.math.ones, self.varshape, batch_size))
-        self.O1 = State4Integral(bst.init.param(bu.math.ones, self.varshape, batch_size))
-        self.O2 = State4Integral(bst.init.param(bu.math.ones, self.varshape, batch_size))
+        self.C1 = DiffEqState(bst.init.param(bu.math.ones, self.varshape, batch_size))
+        self.C2 = DiffEqState(bst.init.param(bu.math.ones, self.varshape, batch_size))
+        self.C3 = DiffEqState(bst.init.param(bu.math.ones, self.varshape, batch_size))
+        self.C4 = DiffEqState(bst.init.param(bu.math.ones, self.varshape, batch_size))
+        self.O1 = DiffEqState(bst.init.param(bu.math.ones, self.varshape, batch_size))
+        self.O2 = DiffEqState(bst.init.param(bu.math.ones, self.varshape, batch_size))
         self.normalize_states([self.C1, self.C2, self.C3, self.C4, self.O1, self.O2])
 
     def reset_state(self, V, K: IonInfo, Ca: IonInfo, batch_size=None):
@@ -371,10 +371,10 @@ class IKca1_1_Ma2020(KCaChannel):
     def init_state(self, V, K: IonInfo, Ca: IonInfo, batch_size=None):
 
         for i in range(5):
-            setattr(self, f'C{i}', State4Integral(bst.init.param(bu.math.ones, self.varshape, batch_size)))
+            setattr(self, f'C{i}', DiffEqState(bst.init.param(bu.math.ones, self.varshape, batch_size)))
 
         for i in range(5):
-            setattr(self, f'O{i}', State4Integral(bst.init.param(bu.math.ones, self.varshape, batch_size)))
+            setattr(self, f'O{i}', DiffEqState(bst.init.param(bu.math.ones, self.varshape, batch_size)))
 
         self.normalize_states([getattr(self, f'C{i}') for i in range(5)] + [getattr(self, f'O{i}') for i in range(5)])
 

--- a/dendritex/channels/potassium_calcium.py
+++ b/dendritex/channels/potassium_calcium.py
@@ -13,7 +13,8 @@ import brainstate as bst
 import brainunit as bu
 import jax
 
-from dendritex._base import IonInfo, Channel, State4Integral
+from dendritex._base import IonInfo, Channel
+from dendritex._integrators import State4Integral
 from dendritex.ions import Calcium, Potassium
 
 __all__ = [
@@ -30,10 +31,10 @@ class KCaChannel(Channel):
 
     root_type = bst.mixin.JointTypes[Potassium, Calcium]
 
-    def before_integral(self, V, K: IonInfo, Ca: IonInfo):
+    def pre_integral(self, V, K: IonInfo, Ca: IonInfo):
         pass
 
-    def post_derivative(self, V, K: IonInfo, Ca: IonInfo):
+    def post_integral(self, V, K: IonInfo, Ca: IonInfo):
         pass
 
     def compute_derivative(self, V, K: IonInfo, Ca: IonInfo):
@@ -270,7 +271,7 @@ class IKca2_2_Ma2020(KCaChannel):
     def current(self, V, K: IonInfo, Ca: IonInfo):
         return self.g_max * (self.O1.value + self.O2.value) * (K.E - V)
 
-    def before_integral(self, V, K: IonInfo, Ca: IonInfo):
+    def pre_integral(self, V, K: IonInfo, Ca: IonInfo):
         self.normalize_states([self.C1, self.C2, self.C3, self.C4, self.O1, self.O2])
 
     def normalize_states(self, states):
@@ -383,7 +384,7 @@ class IKca1_1_Ma2020(KCaChannel):
     def current(self, V, K: IonInfo, Ca: IonInfo):
         return self.g_max * (self.O1.value + self.O2.value) * (K.E - V)
 
-    def before_integral(self, V, K: IonInfo, Ca: IonInfo):
+    def pre_integral(self, V, K: IonInfo, Ca: IonInfo):
         self.normalize_states([getattr(self, f'C{i}') for i in range(5)] + [getattr(self, f'O{i}') for i in range(5)])
 
     def normalize_states(self, states):
@@ -397,7 +398,7 @@ class IKca1_1_Ma2020(KCaChannel):
     def compute_derivative(self, V, K: IonInfo, Ca: IonInfo):
 
         self.C0.derivative = (self.C1 * self.c10(Ca) + self.O0 * self.b0(V) - self.C0 * (
-                self.c01(Ca) + self.f0(V))) / bu.ms
+            self.c01(Ca) + self.f0(V))) / bu.ms
         self.C1.derivative = (self.C0 * self.c01(Ca) + self.C2 * self.c21(Ca) + self.O1 * self.b1(V) - self.C1 * (
             self.c10(Ca) + self.c12(Ca) + self.f1(V))) / bu.ms
         self.C2.derivative = (self.C1 * self.c12(Ca) + self.C3 * self.c32(Ca) + self.O2 * self.b2(V) - self.C2 * (
@@ -405,10 +406,10 @@ class IKca1_1_Ma2020(KCaChannel):
         self.C3.derivative = (self.C2 * self.c23(Ca) + self.C4 * self.c43(Ca) + self.O3 * self.b3(V) - self.C3 * (
             self.c32(Ca) + self.c34(Ca) + self.f3(V))) / bu.ms
         self.C4.derivative = (self.C3 * self.c34(Ca) + self.O4 * self.b4(V) - self.C4 * (
-                self.c43(Ca) + self.f4(V))) / bu.ms
+            self.c43(Ca) + self.f4(V))) / bu.ms
 
         self.O0.derivative = (self.O1 * self.o10(Ca) + self.C0 * self.f0(V) - self.O0 * (
-                self.o01(Ca) + self.b0(V))) / bu.ms
+            self.o01(Ca) + self.b0(V))) / bu.ms
         self.O1.derivative = (self.O0 * self.o01(Ca) + self.O2 * self.o21(Ca) + self.C1 * self.f1(V) - self.O1 * (
             self.o10(Ca) + self.o12(Ca) + self.b1(V))) / bu.ms
         self.O2.derivative = (self.O1 * self.o12(Ca) + self.O3 * self.o32(Ca) + self.C2 * self.f2(V) - self.O2 * (
@@ -416,7 +417,7 @@ class IKca1_1_Ma2020(KCaChannel):
         self.O3.derivative = (self.O2 * self.o23(Ca) + self.O4 * self.o43(Ca) + self.C3 * self.f3(V) - self.O3 * (
             self.o32(Ca) + self.o34(Ca) + self.b3(V))) / bu.ms
         self.O4.derivative = (self.O3 * self.o34(Ca) + self.C4 * self.f4(V) - self.O4 * (
-                self.o43(Ca) + self.b4(V))) / bu.ms
+            self.o43(Ca) + self.b4(V))) / bu.ms
 
     def current(self, V, K: IonInfo, Ca: IonInfo):
         return self.g_max * (self.O0.value + self.O1.value + self.O2.value + self.O3.value + self.O4.value) * (K.E - V)

--- a/dendritex/channels/sodium.py
+++ b/dendritex/channels/sodium.py
@@ -13,7 +13,7 @@ import brainstate as bst
 import brainunit as u
 
 from dendritex._base import Channel, IonInfo
-from dendritex._integrators import State4Integral
+from dendritex._integrators import DiffEqState
 from dendritex.ions import Sodium
 
 __all__ = [
@@ -91,8 +91,8 @@ class INa_p3q_markov(SodiumChannel):
         self.g_max = bst.init.param(g_max, self.varshape, allow_none=False)
 
     def init_state(self, V, Na: IonInfo, batch_size=None):
-        self.p = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.q = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.p = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.q = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
 
     def reset_state(self, V, Na: IonInfo, batch_size=None):
         alpha = self.f_p_alpha(V)
@@ -403,19 +403,19 @@ class INa_Rsg(SodiumChannel):
 
     def init_state(self, V, Na: IonInfo, batch_size=None):
 
-        self.C1 = State4Integral(bst.init.param(u.math.ones, self.varshape, batch_size))
-        self.C2 = State4Integral(bst.init.param(u.math.ones, self.varshape, batch_size))
-        self.C3 = State4Integral(bst.init.param(u.math.ones, self.varshape, batch_size))
-        self.C4 = State4Integral(bst.init.param(u.math.ones, self.varshape, batch_size))
-        self.C5 = State4Integral(bst.init.param(u.math.ones, self.varshape, batch_size))
-        self.I1 = State4Integral(bst.init.param(u.math.ones, self.varshape, batch_size))
-        self.I2 = State4Integral(bst.init.param(u.math.ones, self.varshape, batch_size))
-        self.I3 = State4Integral(bst.init.param(u.math.ones, self.varshape, batch_size))
-        self.I4 = State4Integral(bst.init.param(u.math.ones, self.varshape, batch_size))
-        self.I5 = State4Integral(bst.init.param(u.math.ones, self.varshape, batch_size))
-        self.O = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.B = State4Integral(bst.init.param(u.math.zeros, self.varshape, batch_size))
-        self.I6 = State4Integral(bst.init.param(u.math.ones, self.varshape, batch_size))
+        self.C1 = DiffEqState(bst.init.param(u.math.ones, self.varshape, batch_size))
+        self.C2 = DiffEqState(bst.init.param(u.math.ones, self.varshape, batch_size))
+        self.C3 = DiffEqState(bst.init.param(u.math.ones, self.varshape, batch_size))
+        self.C4 = DiffEqState(bst.init.param(u.math.ones, self.varshape, batch_size))
+        self.C5 = DiffEqState(bst.init.param(u.math.ones, self.varshape, batch_size))
+        self.I1 = DiffEqState(bst.init.param(u.math.ones, self.varshape, batch_size))
+        self.I2 = DiffEqState(bst.init.param(u.math.ones, self.varshape, batch_size))
+        self.I3 = DiffEqState(bst.init.param(u.math.ones, self.varshape, batch_size))
+        self.I4 = DiffEqState(bst.init.param(u.math.ones, self.varshape, batch_size))
+        self.I5 = DiffEqState(bst.init.param(u.math.ones, self.varshape, batch_size))
+        self.O = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.B = DiffEqState(bst.init.param(u.math.zeros, self.varshape, batch_size))
+        self.I6 = DiffEqState(bst.init.param(u.math.ones, self.varshape, batch_size))
         self.normalize_states(
             [self.C1, self.C2, self.C3, self.C4, self.C5, self.I1, self.I2, self.I3, self.I4, self.I5, self.O, self.B,
              self.I6])

--- a/dendritex/channels/sodium.py
+++ b/dendritex/channels/sodium.py
@@ -12,7 +12,8 @@ from typing import Union, Callable, Optional
 import brainstate as bst
 import brainunit as u
 
-from dendritex._base import Channel, IonInfo, State4Integral
+from dendritex._base import Channel, IonInfo
+from dendritex._integrators import State4Integral
 from dendritex.ions import Sodium
 
 __all__ = [
@@ -30,10 +31,10 @@ class SodiumChannel(Channel):
 
     root_type = Sodium
 
-    def before_integral(self, V, Na: IonInfo):
+    def pre_integral(self, V, Na: IonInfo):
         pass
 
-    def post_derivative(self, V, Na: IonInfo):
+    def post_integral(self, V, Na: IonInfo):
         pass
 
     def compute_derivative(self, V, Na: IonInfo):
@@ -427,7 +428,7 @@ class INa_Rsg(SodiumChannel):
         for state in states:
             state.value = state.value / total
 
-    def before_integral(self, V, Na: IonInfo):
+    def pre_integral(self, V, Na: IonInfo):
         self.normalize_states(
             [self.C1, self.C2, self.C3, self.C4, self.C5, self.I1, self.I2, self.I3, self.I4, self.I5, self.O, self.B,
              self.I6])

--- a/dendritex/ions/calcium.py
+++ b/dendritex/ions/calcium.py
@@ -23,7 +23,7 @@ import brainstate as bst
 import brainunit as u
 
 from dendritex._base import Ion, Channel, HHTypedNeuron
-from dendritex._integrators import State4Integral
+from dendritex._integrators import DiffEqState
 
 __all__ = [
     'Calcium',
@@ -107,7 +107,7 @@ class _CalciumDynamics(Calcium):
 
     def init_state(self, V, batch_size=None):
         # Calcium concentration
-        self.C = State4Integral(bst.init.param(self._C_initializer, self.varshape, batch_size))
+        self.C = DiffEqState(bst.init.param(self._C_initializer, self.varshape, batch_size))
         super().init_state(V, batch_size)
 
     def reset_state(self, V, batch_size=None):

--- a/dendritex/ions/calcium.py
+++ b/dendritex/ions/calcium.py
@@ -22,7 +22,8 @@ from typing import Union, Callable, Optional
 import brainstate as bst
 import brainunit as u
 
-from dendritex._base import Ion, Channel, HHTypedNeuron, State4Integral
+from dendritex._base import Ion, Channel, HHTypedNeuron
+from dendritex._integrators import State4Integral
 
 __all__ = [
     'Calcium',

--- a/dendritex/neurons/multi_compartment.py
+++ b/dendritex/neurons/multi_compartment.py
@@ -23,7 +23,7 @@ import jax
 import numpy as np
 
 from dendritex._base import HHTypedNeuron, IonChannel
-from dendritex._integrators import State4Integral
+from dendritex._integrators import DiffEqState
 
 __all__ = [
     'MultiCompartment',
@@ -172,7 +172,7 @@ class MultiCompartment(HHTypedNeuron):
         self.spk_fun = spk_fun
 
     def init_state(self, batch_size=None):
-        self.V = State4Integral(bst.init.param(self.V_initializer, self.varshape, batch_size))
+        self.V = DiffEqState(bst.init.param(self.V_initializer, self.varshape, batch_size))
         self._v_last_time = None
         super().init_state(batch_size)
 

--- a/dendritex/neurons/multi_compartment.py
+++ b/dendritex/neurons/multi_compartment.py
@@ -22,7 +22,8 @@ import brainunit as bu
 import jax
 import numpy as np
 
-from dendritex._base import HHTypedNeuron, State4Integral, IonChannel
+from dendritex._base import HHTypedNeuron, IonChannel
+from dendritex._integrators import State4Integral
 
 __all__ = [
     'MultiCompartment',
@@ -180,11 +181,10 @@ class MultiCompartment(HHTypedNeuron):
         self._v_last_time = None
         super().reset_state(batch_size)
 
-    def before_integral(self, *args):
+    def pre_integral(self, *args):
         self._v_last_time = self.V.value
-        channels = self.nodes(allowed_hierarchy=(1, 1)).filter(IonChannel)
-        for node in channels.values():
-            node.before_integral(self.V.value)
+        for key, node in self.nodes(IonChannel, allowed_hierarchy=(1, 1)).items():
+            node.pre_integral(self.V.value)
 
     def compute_derivative(self, I_ext=0. * bu.nA):
         # [ Compute the derivative of membrane potential ]
@@ -196,24 +196,20 @@ class MultiCompartment(HHTypedNeuron):
         I_syn = self.sum_current_inputs(0. * bu.nA / bu.cm ** 2, self.V.value)
         # 3. channel currents
         I_channel = None
-        for ch in self.nodes(allowed_hierarchy=(1, 1)).filter(IonChannel).values():
+        for key, ch in self.nodes(IonChannel, allowed_hierarchy=(1, 1)).items():
             I_channel = ch.current(self.V.value) if I_channel is None else (I_channel + ch.current(self.V.value))
         # 4. derivatives
         self.V.derivative = (I_ext + I_axial + I_syn + I_channel) / self.cm
 
         # [ integrate dynamics of ion and ion channels ]
         # check whether the children channels have the correct parents.
-        channels = self.nodes(allowed_hierarchy=(1, 1)).filter(IonChannel)
-        for node in channels.values():
+        for key, node in self.nodes(IonChannel, allowed_hierarchy=(1, 1)).items():
             node.compute_derivative(self.V.value)
 
-    def post_derivative(self, *args):
-        self.V.value = self.sum_delta_inputs(init=self.V.value)
-        channels = self.nodes(allowed_hierarchy=(1, 1)).filter(IonChannel)
-        for node in channels.values():
-            node.post_derivative(self.V.value)
-
     def update(self, *args):
+        self.V.value = self.sum_delta_inputs(init=self.V.value)
+        for key, node in self.nodes(IonChannel, allowed_hierarchy=(1, 1)).items():
+            node.post_integral(self.V.value)
         return self.get_spike()
 
     def get_spike(self):

--- a/dendritex/neurons/single_compartment.py
+++ b/dendritex/neurons/single_compartment.py
@@ -21,7 +21,7 @@ import brainstate as bst
 import brainunit as u
 
 from dendritex._base import HHTypedNeuron, IonChannel
-from dendritex._integrators import State4Integral
+from dendritex._integrators import DiffEqState
 
 __all__ = [
     'SingleCompartment',
@@ -85,7 +85,7 @@ class SingleCompartment(HHTypedNeuron):
         self.spk_fun = spk_fun
 
     def init_state(self, batch_size=None):
-        self.V = State4Integral(bst.init.param(self.V_initializer, self.varshape, batch_size))
+        self.V = DiffEqState(bst.init.param(self.V_initializer, self.varshape, batch_size))
         self._v_last_time = None
         super().init_state(batch_size)
 

--- a/examples/calcium_activation_functions.py
+++ b/examples/calcium_activation_functions.py
@@ -1,0 +1,51 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+
+import brainunit as bu
+import matplotlib.pyplot as plt
+import braintools as bts
+
+import dendritex as dx
+
+cat = dx.channels.ICaT_HP1992(1)
+caht = dx.channels.ICaHT_HM1992(1)
+
+vs = bu.math.arange(-100 * bu.mV, 0 * bu.mV, 0.1 * bu.mV)
+
+fig, gs = bts.visualize.get_figure(1, 2, 3., 4.5)
+
+q_inf = cat.f_q_inf(vs)
+p_inf = cat.f_p_inf(vs)
+
+fig.add_subplot(gs[0, 0])
+plt.plot(vs / bu.mV, q_inf, label='q_inf')
+plt.plot(vs / bu.mV, p_inf, label='p_inf')
+plt.legend()
+plt.fill_between([-80, -60], 1., alpha=0.2)
+plt.title('Low-threshold Calcium Channel')
+plt.xlabel('mV')
+# plt.show()
+
+q_inf = caht.f_q_inf(vs)
+p_inf = caht.f_p_inf(vs)
+fig.add_subplot(gs[0, 1])
+plt.plot(vs / bu.mV, q_inf, label='q_inf')
+plt.plot(vs / bu.mV, p_inf, label='p_inf')
+plt.fill_between([-60, -40], 1., alpha=0.2)
+plt.legend()
+plt.xlabel('mV')
+plt.title('High-threshold Calcium Channel')
+plt.show()

--- a/examples/fitting_a_hh_neuron/main.py
+++ b/examples/fitting_a_hh_neuron/main.py
@@ -53,8 +53,8 @@ class INa(dx.Channel):
         self.V_th = bst.init.param(vth, self.varshape)
 
     def init_state(self, V, batch_size=None):
-        self.m = dx.State4Integral(bst.init.param(u.math.zeros, self.varshape))
-        self.h = dx.State4Integral(bst.init.param(u.math.zeros, self.varshape))
+        self.m = dx.DiffEqState(bst.init.param(u.math.zeros, self.varshape))
+        self.h = dx.DiffEqState(bst.init.param(u.math.zeros, self.varshape))
 
     #  m channel
     m_alpha = lambda self, V: 0.32 * 4 / u.math.exprel((13. * u.mV - V + self.V_th).to_decimal(u.mV) / 4.)
@@ -94,7 +94,7 @@ class IK(dx.Channel):
         self.V_th = bst.init.param(vth, self.varshape)
 
     def init_state(self, V, batch_size=None):
-        self.n = dx.State4Integral(bst.init.param(u.math.zeros, self.varshape))
+        self.n = dx.DiffEqState(bst.init.param(u.math.zeros, self.varshape))
 
     # n channel
     n_alpha = lambda self, V: 0.032 * 5 / u.math.exprel((15. * u.mV - V + self.V_th).to_decimal(u.mV) / 5.)
@@ -131,11 +131,11 @@ def visualize_target(voltages):
     times = np.arange(voltages.shape[0]) * 0.01
     for i in range(voltages.shape[1]):
         ax = fig.add_subplot(gs[0, i])
-        ax.plot(times, voltages.mantissa[:, i], label='target')
+        ax.plot(times, voltages[:, i], label='target')
         plt.xlabel('Time [ms]')
         plt.legend()
         ax = plt.subplot(gs[1, i])
-        ax.plot(times, inp_traces[i].mantissa)
+        ax.plot(times, inp_traces[i])
         plt.xlabel('Time [ms]')
     plt.show()
 
@@ -145,7 +145,6 @@ def visualize(voltages, gl, g_na, g_kd, C):
     # voltages: [T, B]
     simulated_vs = simulate_model(gl, g_na, g_kd, C)
     voltages = voltages.mantissa
-    simulated_vs = simulated_vs.mantissa
 
     fig, gs = bts.visualize.get_figure(2, simulated_vs.shape[1], 3, 4.5)
     for i in range(simulated_vs.shape[1]):
@@ -154,7 +153,7 @@ def visualize(voltages, gl, g_na, g_kd, C):
         ax.plot(simulated_vs[:, i], label='simulated')
         plt.legend()
         ax = plt.subplot(gs[1, i])
-        ax.plot(inp_traces[i].mantissa)
+        ax.plot(inp_traces[i])
     plt.show()
 
 

--- a/examples/hh_neuron.py
+++ b/examples/hh_neuron.py
@@ -35,10 +35,8 @@ class HH(dx.neurons.SingleCompartment):
         self.IL = dx.channels.IL(size, E=-54.387 * u.mV, g_max=0.03 * (u.mS / u.cm ** 2))
 
     def step_fun(self, t):
-        # dx.euler_step(hh, t, 10 * u.nA)
-        # dx.rk2_step(hh, t, 10 * u.nA)
-        # dx.rk3_step(hh, t, 10 * u.nA)
         dx.rk2_step(self, t, 10 * u.nA / u.cm ** 2)
+        # spike = self.update()
         return self.V.value
 
 

--- a/examples/simple_dendrite_model.py
+++ b/examples/simple_dendrite_model.py
@@ -28,8 +28,8 @@ class INa(dx.channels.SodiumChannel):
         self.g_max = bst.init.param(g_max, self.varshape)
 
     def init_state(self, V, Na: dx.IonInfo, batch_size: int = None):
-        self.m = dx.State4Integral(self.m_inf(V))
-        self.h = dx.State4Integral(self.h_inf(V))
+        self.m = dx.DiffEqState(self.m_inf(V))
+        self.h = dx.DiffEqState(self.h_inf(V))
 
     def compute_derivative(self, V, Na: dx.IonInfo):
         self.m.derivative = (self.m_alpha(V) * (1 - self.m.value) - self.m_beta(V) * self.m.value) / u.ms
@@ -55,7 +55,7 @@ class IK(dx.channels.PotassiumChannel):
         self.g_max = bst.init.param(g_max, self.varshape)
 
     def init_state(self, V, K: dx.IonInfo, batch_size: int = None):
-        self.n = dx.State4Integral(self.n_inf(V))
+        self.n = dx.DiffEqState(self.n_inf(V))
 
     def compute_derivative(self, V, K: dx.IonInfo):
         self.n.derivative = (self.n_alpha(V) * (1 - self.n.value) - self.n_beta(V) * self.n.value) / u.ms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dependencies = [
     'numpy',
     'brainstate>=0.1.0',
     'brainunit>=0.0.2.post20240903',
-    'diffrax',
 ]
 
 dynamic = ['version']
@@ -59,8 +58,8 @@ dynamic = ['version']
 name = "dendritex"
 
 [project.urls]
-homepage = 'http://github.com/chaoming0625/dendritex'
-repository = 'http://github.com/chaoming0625/dendritex'
+homepage = 'http://github.com/chaobrain/dendritex'
+repository = 'http://github.com/chaobrain/dendritex'
 
 [project.optional-dependencies]
 testing = [

--- a/setup.py
+++ b/setup.py
@@ -58,12 +58,12 @@ setup(
     author_email='chao.brain@qq.com',
     packages=packages,
     python_requires='>=3.9',
-    install_requires=['numpy>=1.15', 'jax', 'brainunit>=0.0.2.post20240903', 'brainstate>=0.1.0', 'diffrax'],
-    url='https://github.com/chaoming0625/dendritex',
+    install_requires=['numpy>=1.15', 'jax', 'brainunit>=0.0.2.post20240903', 'brainstate>=0.1.0'],
+    url='https://github.com/chaobrain/dendritex',
     project_urls={
-        "Bug Tracker": "https://github.com/chaoming0625/dendritex/issues",
+        "Bug Tracker": "https://github.com/chaobrain/dendritex/issues",
         "Documentation": "https://dendrite.readthedocs.io/",
-        "Source Code": "https://github.com/chaoming0625/dendritex",
+        "Source Code": "https://github.com/chaobrain/dendritex",
     },
     extras_require={
         'cpu': ['jaxlib'],


### PR DESCRIPTION
This pull request includes major changes to the `dendritex` library, particularly focusing on refactoring and improving the differential equation integration modules. The most important changes include the removal of the `State4Integral` and `DendriteDynamics` classes, the introduction of the `DiffEqState` and `DiffEqModule` classes, and the renaming of several methods for consistency.

Refactoring and improvements:

* Removed `State4Integral` and `DendriteDynamics` classes, and introduced `DiffEqState` and `DiffEqModule` classes in `dendritex/_integrators.py`. This change simplifies the integration of differential equations and ensures better modularity. [[1]](diffhunk://#diff-de38e957ca9be8b2ae86d95115637dcf485d7298f460b7cf5a48c55fbd644185L52-R52) [[2]](diffhunk://#diff-b524ea36ea425a7f694df61daa270f427f3eb0aa65f4c0ae8225bd8855012187R52-R135)
* Replaced all instances of `DendriteDynamics` with `DiffEqModule` in `dendritex/_base.py` and `dendritex/_integrators.py` to reflect the new class structure. [[1]](diffhunk://#diff-de38e957ca9be8b2ae86d95115637dcf485d7298f460b7cf5a48c55fbd644185L303-R185) [[2]](diffhunk://#diff-de38e957ca9be8b2ae86d95115637dcf485d7298f460b7cf5a48c55fbd644185L350-R245) [[3]](diffhunk://#diff-b524ea36ea425a7f694df61daa270f427f3eb0aa65f4c0ae8225bd8855012187L435-R633)
* Renamed methods `before_integral` and `post_derivative` to `pre_integral` and `post_integral`, respectively, for better clarity and consistency in `dendritex/_base.py`. [[1]](diffhunk://#diff-de38e957ca9be8b2ae86d95115637dcf485d7298f460b7cf5a48c55fbd644185L221-R113) [[2]](diffhunk://#diff-de38e957ca9be8b2ae86d95115637dcf485d7298f460b7cf5a48c55fbd644185L252-R128) [[3]](diffhunk://#diff-de38e957ca9be8b2ae86d95115637dcf485d7298f460b7cf5a48c55fbd644185L463-R355)
* Added a check for the presence of the `diffrax` package and conditionally imported it in `dendritex/_integrators.py` to ensure compatibility and prevent import errors. [[1]](diffhunk://#diff-b524ea36ea425a7f694df61daa270f427f3eb0aa65f4c0ae8225bd8855012187R18-R31) [[2]](diffhunk://#diff-b524ea36ea425a7f694df61daa270f427f3eb0aa65f4c0ae8225bd8855012187R155-R157)
* Updated the Runge-Kutta integration methods to use the new `DiffEqModule` class and refactored the `_rk_update` function for better readability and maintainability in `dendritex/_integrators.py`. [[1]](diffhunk://#diff-b524ea36ea425a7f694df61daa270f427f3eb0aa65f4c0ae8225bd8855012187L363-R504) [[2]](diffhunk://#diff-b524ea36ea425a7f694df61daa270f427f3eb0aa65f4c0ae8225bd8855012187L435-R633)

## Summary by Sourcery

Refactor the differential equation integration modules by replacing the `State4Integral` and `DendriteDynamics` classes with `DiffEqState` and `DiffEqModule`, respectively. Rename `before_integral` and `post_derivative` to `pre_integral` and `post_integral` for consistency. Add a check for the `diffrax` package and update the Runge-Kutta integration methods.

New Features:
- Introduce the `DiffEqState` class to manage the state of differential equations, including derivatives and diffusion.
- Introduce the `DiffEqModule` class to encapsulate the logic for computing derivatives and handling pre- and post-integration steps.

Enhancements:
- Standardize integration methods for differential equations, simplifying the process and improving modularity.

Tests:
- Add a conditional import for the `diffrax` package to ensure compatibility and prevent import errors.